### PR TITLE
Add text informing that no prediction could be given

### DIFF
--- a/src/components/turnipWeekPredicter.tsx
+++ b/src/components/turnipWeekPredicter.tsx
@@ -41,6 +41,10 @@ export const TurnipWeekPredicter = observer((props: TurnipWeekPredicterProps) =>
           ? <div className={"pattern-prediction"}><p>S Spike:</p><p>{`${(possiblePatterns.pattern3?.probability * 100).toFixed()}%`}</p></div>
           : null
         }
+        {prices.some(p => p !== '') && !(possiblePatterns.pattern0.probability || possiblePatterns.pattern1.probability || possiblePatterns.pattern2.probability || possiblePatterns.pattern3.probability)
+            ? <p>Prediction failed</p>
+            : null
+        }
         {
           prices.some(p => p !== '') ? <a href={prophetURL} className={"prophet-url"} target="_blank">Possible prices</a> : null
         }

--- a/src/components/turnipWeekPredicter.tsx
+++ b/src/components/turnipWeekPredicter.tsx
@@ -23,6 +23,7 @@ export const TurnipWeekPredicter = observer((props: TurnipWeekPredicterProps) =>
     prices.splice(1,1)
     const prophetPrevPattern = (previousPattern !== '' ? previousPattern.substring(0, 7) + '=' + previousPattern.substring(7, previousPattern.length) : '')
     const prophetURL = `https://turnipprophet.io?prices=${prices.join('.')}${previousPattern !== '' ? '&' + prophetPrevPattern : ''}`
+    const predictionFailed = prices.some(p => p !== '') && !(possiblePatterns.pattern0.probability || possiblePatterns.pattern1.probability || possiblePatterns.pattern2.probability || possiblePatterns.pattern3.probability);
     return (
       <div className={"pattern-predictions-container"}>
         {possiblePatterns.pattern0.probability
@@ -41,10 +42,8 @@ export const TurnipWeekPredicter = observer((props: TurnipWeekPredicterProps) =>
           ? <div className={"pattern-prediction"}><p>S Spike:</p><p>{`${(possiblePatterns.pattern3?.probability * 100).toFixed()}%`}</p></div>
           : null
         }
-        {prices.some(p => p !== '') && !(possiblePatterns.pattern0.probability || possiblePatterns.pattern1.probability || possiblePatterns.pattern2.probability || possiblePatterns.pattern3.probability)
-            ? <p>Prediction failed</p>
-            : null
-        }
+        {predictionFailed && <p>Prediction failed</p>}
+        {predictionFailed && prices[0] === '' && <p><i>No buy price</i></p>}
         {
           prices.some(p => p !== '') ? <a href={prophetURL} className={"prophet-url"} target="_blank">Possible prices</a> : null
         }


### PR DESCRIPTION
Instead of displaying no prediction and only a link to Turnip Prophet, display text that no prediction could be found. This is to easier understand why no prediction is displayed, even though prices have been provided for the week.